### PR TITLE
Add option to specify encoding

### DIFF
--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -23,7 +23,7 @@ def get_row_iterator(iterable, options=None, headers_in_catalog = None, with_dup
     options = options or {}
     reader = []
     headers = set()
-    file_stream = codecs.iterdecode(iterable, encoding=options.get('encoding', 'utf-8'))
+    file_stream = codecs.iterdecode(iterable, encoding=options.get('encoding', 'utf-8-sig'))
     delimiter = options.get('delimiter', ',')
     remove_character = options.get('remove_character', '')
 

--- a/singer_encodings/json_schema.py
+++ b/singer_encodings/json_schema.py
@@ -46,7 +46,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records):
 
     # Add file_name to opts and flag infer_compression to support gzipped files
     opts = {'key_properties': table_spec['key_properties'],
-            'encoding': table_spec.get('encoding', 'utf-8'),
+            'encoding': table_spec.get('encoding', 'utf-8-sig'),
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath']}
 


### PR DESCRIPTION
# Description of change
Allow the `encoding` option

# Manual QA steps
This was tested on local data that contained `u'\xa0'` - with the default encoding of `utf-8-sig` this caused errors:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 75: invalid start byte
```

Adding the `encoding` option to `singer-encodings` and then providing:

```json
[
    {
        "search_prefix": "some_folder/",
        "search_pattern": "SOME_FILE_[0-9]+[.]csv",
        "table_name": "LOAD_SOME_FILE",
        "key_properties": [],
        "delimiter": ",",
        "encoding": "cp1252"
    }
]
```

Resulted in no encoding errors. 

# Risks
 - 
 
# Rollback steps
 - revert this branch
